### PR TITLE
Update Tokio to 0.2.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,9 +598,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05c1d570eb1a36f0345a5ce9c6c6e665b70b73d11236912c0b477616aeec47b1"
+checksum = "d099fa27b9702bed751524694adbe393e18b36b204da91eb1cbbbbb4a5ee2d58"
 dependencies = [
  "bytes",
  "fnv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ async-stream = "0.2.1"
 atoi = "0.3.2"
 bytes = "0.5.4"
 structopt = "0.3.14"
-tokio = { version = "0.2.20", features = ["full"] }
+tokio = { version = "0.2.21", features = ["full"] }
 tracing = "0.1.13"
 tracing-futures = { version = "0.2.3" }
 tracing-subscriber = "0.2.2"


### PR DESCRIPTION
As Tokio [version 0.2.21][1] contains a fix in the broadcast channel that removes a memory leak in mini-redis, I don't think 0.2.20 should be considered the minimum supported version, even if the codebase compiles with that version.

Refs: #38

[1]: https://github.com/tokio-rs/tokio/releases/tag/tokio-0.2.21