### PR TITLE
Update Cargo.toml to change `cli` and `server` binary names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ larger example of an idiomatic Tokio application.
 """
 
 [[bin]]
-name = "mini-redis-cli"
+name = "cli"
 path = "src/bin/cli.rs"
 
 [[bin]]
-name = "mini-redis-server"
+name = "server"
 path = "src/bin/server.rs"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ larger example of an idiomatic Tokio application.
 """
 
 [[bin]]
-name = "cli"
+name = "mini-redis-cli"
 path = "src/bin/cli.rs"
 
 [[bin]]
-name = "server"
+name = "mini-redis-server"
 path = "src/bin/server.rs"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ for interacting with the server.
 Start the server:
 
 ```
-RUST_LOG=debug cargo run --bin server
+RUST_LOG=debug cargo run --bin mini-redis-server
 ```
 
 The [`tracing`](https://github.com/tokio-rs/tracing) crate is used to provide structured logs.
@@ -51,9 +51,9 @@ Additionally, a CLI client is provided to run arbitrary commands from the
 terminal. With the server running, the following works:
 
 ```
-cargo run --bin cli set foo bar
+cargo run --bin mini-redis-cli set foo bar
 
-cargo run --bin cli get foo
+cargo run --bin mini-redis-cli get foo
 ```
 
 ## Supported commands


### PR DESCRIPTION
When you run the server like the README says, you get an error:

```shell
$ cargo run --bin server

error: no bin target named `server`
```

Same happens with `cli` also. 

I believe this is happening cos how they are declared in the Cargo:

```toml
[[bin]]
name = "mini-redis-cli"
path = "src/bin/cli.rs"

[[bin]]
name = "mini-redis-server"
path = "src/bin/server.rs"
```

This PR fixes this. Instead of editing README, I edited the Cargo itself cos I thought it will be easier to type `server` often than `mini-redis-server`