### PR TITLE
Remove unnecessary allocations

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -19,7 +19,7 @@ pub async fn main() -> mini_redis::Result<()> {
     tracing_subscriber::fmt::try_init()?;
 
     let cli = Cli::from_args();
-    let port = cli.port.unwrap_or(DEFAULT_PORT.to_string());
+    let port = cli.port.as_deref().unwrap_or(DEFAULT_PORT);
 
     // Bind a TCP listener
     let listener = TcpListener::bind(&format!("127.0.0.1:{}", port)).await?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -323,7 +323,7 @@ impl Client {
                     // num-subscribed is the number of channels that the client
                     // is currently subscribed to.
                     [subscribe, schannel, ..]
-                        if **subscribe == "subscribe" && **schannel == channel => {}
+                        if *subscribe == "subscribe" && *schannel == channel => {}
                     _ => return Err(response.to_error()),
                 },
                 frame => return Err(frame.to_error()),
@@ -374,12 +374,10 @@ impl Subscriber {
 
                 match mframe {
                     Frame::Array(ref frame) => match frame.as_slice() {
-                        [message, channel, content] if **message == "message" => {
-                            Ok(Some(Message {
-                                channel: channel.to_string(),
-                                content: Bytes::from(content.to_string()),
-                            }))
-                        }
+                        [message, channel, content] if *message == "message" => Ok(Some(Message {
+                            channel: channel.to_string(),
+                            content: Bytes::from(content.to_string()),
+                        })),
                         _ => Err(mframe.to_error()),
                     },
                     frame => Err(frame.to_error()),
@@ -447,7 +445,7 @@ impl Subscriber {
 
             match response {
                 Frame::Array(ref frame) => match frame.as_slice() {
-                    [unsubscribe, channel, ..] if **unsubscribe == "unsubscribe" => {
+                    [unsubscribe, channel, ..] if *unsubscribe == "unsubscribe" => {
                         let len = self.subscribed_channels.len();
 
                         if len == 0 {
@@ -456,7 +454,7 @@ impl Subscriber {
                         }
 
                         // unsubscribed channel should exist in the subscribed list at this point
-                        self.subscribed_channels.retain(|c| **channel != &c[..]);
+                        self.subscribed_channels.retain(|c| *channel != &c[..]);
 
                         // Only a single channel should be removed from the
                         // liste of subscribed channels.

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -12,7 +12,7 @@ pub(crate) enum Frame {
     Integer(u64),
     Bulk(Bytes),
     Null,
-    Array(Vec<Box<Frame>>),
+    Array(Vec<Frame>),
 }
 
 #[derive(Debug)]
@@ -38,7 +38,7 @@ impl Frame {
     pub(crate) fn push_bulk(&mut self, bytes: Bytes) {
         match self {
             Frame::Array(vec) => {
-                vec.push(Box::new(Frame::Bulk(bytes)));
+                vec.push(Frame::Bulk(bytes));
             }
             _ => panic!("not an array frame"),
         }
@@ -52,7 +52,7 @@ impl Frame {
     pub(crate) fn push_int(&mut self, value: u64) {
         match self {
             Frame::Array(vec) => {
-                vec.push(Box::new(Frame::Integer(value)));
+                vec.push(Frame::Integer(value));
             }
             _ => panic!("not an array frame"),
         }
@@ -154,7 +154,7 @@ impl Frame {
                 let mut out = Vec::with_capacity(len);
 
                 for _ in 0..len {
-                    out.push(Box::new(Frame::parse(src)?));
+                    out.push(Frame::parse(src)?);
                 }
 
                 Ok(Frame::Array(out))

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -12,7 +12,7 @@ use std::{fmt, str, vec};
 #[derive(Debug)]
 pub(crate) struct Parse {
     /// Array frame iterator.
-    parts: vec::IntoIter<Box<Frame>>,
+    parts: vec::IntoIter<Frame>,
 }
 
 /// Error encountered while parsing a frame.
@@ -47,10 +47,7 @@ impl Parse {
     /// Return the next entry. Array frames are arrays of frames, so the next
     /// entry is a frame.
     fn next(&mut self) -> Result<Frame, ParseError> {
-        self.parts
-            .next()
-            .map(|frame| *frame)
-            .ok_or(ParseError::EndOfStream)
+        self.parts.next().ok_or(ParseError::EndOfStream)
     }
 
     /// Return the next entry as a string.


### PR DESCRIPTION
* `Vec<Box<Frame>>` -> `Vec<Frame>` (`Frame` is small enough that no additional boxing is needed: `std::mem::size_of::<Frame>() == 40`)
* remove a `.to_string()`