### PR TITLE
try to simplify Subscribe::apply

### DIFF
--- a/src/cmd/subscribe.rs
+++ b/src/cmd/subscribe.rs
@@ -251,7 +251,7 @@ fn make_subscribe_frame(channel_name: String, num_subs: usize) -> Frame {
     response
 }
 
-/// Creates the response to a subcribe request.
+/// Creates the response to an unsubcribe request.
 fn make_unsubscribe_frame(channel_name: String, num_subs: usize) -> Frame {
     let mut response = Frame::array();
     response.push_bulk(Bytes::from_static(b"unsubscribe"));


### PR DESCRIPTION
I tried to simplify [`Subscribe::apply`][1] by moving things into separate functions.

[1]: https://github.com/tokio-rs/mini-redis/blob/dc8993b56b8b0842243bbc07b06a4dcda4b409c7/src/cmd/subscribe.rs#L94-L207