### PR TITLE
fix typo

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -102,7 +102,7 @@ impl Frame {
         }
     }
 
-    /// The message has already been validated with `scan`.
+    /// The message has already been validated with `check`.
     pub fn parse(src: &mut Cursor<&[u8]>) -> Result<Frame, Error> {
         match get_u8(src)? {
             b'+' => {


### PR DESCRIPTION
It looks like the scan method doesn't exist. The check is done by the check method.
Perhaps scan was meant as a metaphor for the check method?
Let me know if I misunderstood anything.