### PR TITLE
Remove note about AsyncBufRead

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -24,10 +24,7 @@ pub struct Connection {
     // sufficient for our needs.
     stream: BufWriter<TcpStream>,
 
-    // The buffer for reading frames. Unfortunately, Tokio's `BufReader`
-    // currently requires you to empty its buffer before you can ask it to
-    // retrieve more data from the underlying stream, so we have to manually
-    // implement buffering. This should be fixed in Tokio v0.3.
+    // The buffer for reading frames.
     buffer: BytesMut,
 }
 


### PR DESCRIPTION
This is a follow-up to https://github.com/tokio-rs/mini-redis/pull/67#issuecomment-714780717. We decided to punt changes to `AsyncBufRead` in Tokio 0.3, so this comment is no longer correct.