### PR TITLE
Update write_decimal max string length

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -223,7 +223,7 @@ impl Connection {
         use std::io::Write;
 
         // Convert the value to a string
-        let mut buf = [0u8; 12];
+        let mut buf = [0u8; 20];
         let mut buf = Cursor::new(&mut buf[..]);
         write!(&mut buf, "{}", val)?;
 


### PR DESCRIPTION
The length of `u64::MAX` is 20 characters.