### PR TITLE
Remove `shutdown_complete_rx` from the Listner

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -60,7 +60,6 @@ struct Listener {
     /// complete, all clones of the `Sender` are also dropped. This results in
     /// `shutdown_complete_rx.recv()` completing with `None`. At this point, it
     /// is safe to exit the server process.
-    shutdown_complete_rx: mpsc::Receiver<()>,
     shutdown_complete_tx: mpsc::Sender<()>,
 }
 
@@ -135,7 +134,7 @@ pub async fn run(listener: TcpListener, shutdown: impl Future) {
     // a receiver is needed, the subscribe() method on the sender is used to create
     // one.
     let (notify_shutdown, _) = broadcast::channel(1);
-    let (shutdown_complete_tx, shutdown_complete_rx) = mpsc::channel(1);
+    let (shutdown_complete_tx, mut shutdown_complete_rx) = mpsc::channel(1);
 
     // Initialize the listener state
     let mut server = Listener {
@@ -144,7 +143,6 @@ pub async fn run(listener: TcpListener, shutdown: impl Future) {
         limit_connections: Arc::new(Semaphore::new(MAX_CONNECTIONS)),
         notify_shutdown,
         shutdown_complete_tx,
-        shutdown_complete_rx,
     };
 
     // Concurrently run the server and listen for the `shutdown` signal. The
@@ -188,7 +186,6 @@ pub async fn run(listener: TcpListener, shutdown: impl Future) {
     // explicitly drop `shutdown_transmitter`. This is important, as the
     // `.await` below would otherwise never complete.
     let Listener {
-        mut shutdown_complete_rx,
         shutdown_complete_tx,
         notify_shutdown,
         ..


### PR DESCRIPTION
Fix #88 remove unused field from the Listner struct