### PR TITLE
Remove unused import

### DIFF
--- a/src/cmd/ping.rs
+++ b/src/cmd/ping.rs
@@ -1,6 +1,6 @@
 use crate::{Connection, Frame, Parse, ParseError};
 use bytes::Bytes;
-use tracing::{instrument};
+use tracing::instrument;
 
 /// Returns PONG if no argument is provided, otherwise
 /// return a copy of the argument as a bulk.

--- a/src/cmd/ping.rs
+++ b/src/cmd/ping.rs
@@ -1,6 +1,6 @@
 use crate::{Connection, Frame, Parse, ParseError};
 use bytes::Bytes;
-use tracing::{debug, instrument};
+use tracing::{instrument};
 
 /// Returns PONG if no argument is provided, otherwise
 /// return a copy of the argument as a bulk.


### PR DESCRIPTION
I wanted badly to get rid of this warning every time I try to compile anything.