### PR TITLE
refactor: use `OwnedSemaphore` for connection limiting

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -266,7 +266,7 @@ impl Listener {
                 }
                 // Move the permit into the task and drop it after completion.
                 // This returns the permit back to the semaphore.
-                drop(permit)
+                drop(permit);
             });
         }
     }


### PR DESCRIPTION
The previous drop implementation was a workaround for this, then inexistant API.
