### PR TITLE
Fix tiny typo in server.rs

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -155,7 +155,7 @@ pub async fn run(listener: TcpListener, shutdown: impl Future) {
     // op completes, its associated `<step to perform with result>` is
     // performed.
     //
-    // The `select! macro is a foundational building block for writing
+    // The `select!` macro is a foundational building block for writing
     // asynchronous Rust. See the API docs for more details:
     //
     // https://docs.rs/tokio/*/tokio/macro.select.html


### PR DESCRIPTION
Thank you for awesome project!
I'm learning a lot from this project about async processing in rust.

I found tiny typo in the run function in server.rs and fixed it.