### PR TITLE
chore: update actions/checkout action to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build
       run: cargo build --verbose
     - name: Build with OTel feature


### PR DESCRIPTION
Older versions use node 12 which is no longer supported (end-of-life on April 30, 2022).