### PR TITLE
add rustfmt.toml && simplify PartialEq on str for Frame

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -297,7 +297,7 @@ impl Client {
     /// The core `SUBSCRIBE` logic, used by misc subscribe fns
     async fn subscribe_cmd(&mut self, channels: &[String]) -> crate::Result<()> {
         // Convert the `Subscribe` command into a frame
-        let frame = Subscribe::new(&channels).into_frame();
+        let frame = Subscribe::new(channels).into_frame();
 
         debug!(request = ?frame);
 
@@ -323,7 +323,7 @@ impl Client {
                     // num-subscribed is the number of channels that the client
                     // is currently subscribed to.
                     [subscribe, schannel, ..]
-                        if *subscribe == "subscribe" && *schannel == channel => {}
+                        if subscribe == "subscribe" && schannel == channel.as_str() => {}
                     _ => return Err(response.to_error()),
                 },
                 frame => return Err(frame.to_error()),
@@ -374,7 +374,7 @@ impl Subscriber {
 
                 match mframe {
                     Frame::Array(ref frame) => match frame.as_slice() {
-                        [message, channel, content] if *message == "message" => Ok(Some(Message {
+                        [message, channel, content] if message == "message" => Ok(Some(Message {
                             channel: channel.to_string(),
                             content: Bytes::from(content.to_string()),
                         })),
@@ -423,7 +423,7 @@ impl Subscriber {
     /// Unsubscribe to a list of new channels
     #[instrument(skip(self))]
     pub async fn unsubscribe(&mut self, channels: &[String]) -> crate::Result<()> {
-        let frame = Unsubscribe::new(&channels).into_frame();
+        let frame = Unsubscribe::new(channels).into_frame();
 
         debug!(request = ?frame);
 
@@ -445,7 +445,7 @@ impl Subscriber {
 
             match response {
                 Frame::Array(ref frame) => match frame.as_slice() {
-                    [unsubscribe, channel, ..] if *unsubscribe == "unsubscribe" => {
+                    [unsubscribe, channel, ..] if unsubscribe == "unsubscribe" => {
                         let len = self.subscribed_channels.len();
 
                         if len == 0 {
@@ -454,7 +454,7 @@ impl Subscriber {
                         }
 
                         // unsubscribed channel should exist in the subscribed list at this point
-                        self.subscribed_channels.retain(|c| *channel != &c[..]);
+                        self.subscribed_channels.retain(|c| channel != &c[..]);
 
                         // Only a single channel should be removed from the
                         // list of subscribed channels.

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -173,8 +173,8 @@ impl Frame {
     }
 }
 
-impl PartialEq<&str> for Frame {
-    fn eq(&self, other: &&str) -> bool {
+impl PartialEq<str> for Frame {
+    fn eq(&self, other: &str) -> bool {
         match self {
             Frame::Simple(s) => s.eq(other),
             Frame::Bulk(s) => s.eq(other),


### PR DESCRIPTION
An empty `rustfmt.toml` in project tells rustfmt to use the default rustfmt settings, which won't be affected by global rustfmt config (like in `~/.config/rustfmt/rustfmt.toml`).
