### PR TITLE
Remove unnecessary parameter passing and space

### DIFF
--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -125,7 +125,7 @@ async fn main() -> mini_redis::Result<()> {
             println!("OK");
         }
         Command::Publish { channel, message } => {
-            client.publish(&channel, message.into()).await?;
+            client.publish(&channel, message).await?;
             println!("Publish OK");
         }
         Command::Subscribe { channels } => {

--- a/src/client.rs
+++ b/src/client.rs
@@ -333,7 +333,7 @@ impl Client {
     /// The core `SUBSCRIBE` logic, used by misc subscribe fns
     async fn subscribe_cmd(&mut self, channels: &[String]) -> crate::Result<()> {
         // Convert the `Subscribe` command into a frame
-        let frame = Subscribe::new(&channels).into_frame();
+        let frame = Subscribe::new(channels.to_vec()).into_frame();
 
         debug!(request = ?frame);
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -42,7 +42,7 @@ impl Command {
     ///
     /// On success, the command value is returned, otherwise, `Err` is returned.
     pub fn from_frame(frame: Frame) -> crate::Result<Command> {
-        // The frame  value is decorated with `Parse`. `Parse` provides a
+        // The frame value is decorated with `Parse`. `Parse` provides a
         // "cursor" like API which makes parsing the command easier.
         //
         // The frame value must be an array variant. Any other frame variants

--- a/src/cmd/subscribe.rs
+++ b/src/cmd/subscribe.rs
@@ -35,7 +35,7 @@ type Messages = Pin<Box<dyn Stream<Item = Bytes> + Send>>;
 impl Subscribe {
     /// Creates a new `Subscribe` command to listen on the specified channels.
     pub(crate) fn new(channels: Vec<String>) -> Subscribe {
-        Subscribe {channels}
+        Subscribe { channels }
     }
 
     /// Parse a `Subscribe` instance from a received frame.

--- a/src/cmd/subscribe.rs
+++ b/src/cmd/subscribe.rs
@@ -34,10 +34,8 @@ type Messages = Pin<Box<dyn Stream<Item = Bytes> + Send>>;
 
 impl Subscribe {
     /// Creates a new `Subscribe` command to listen on the specified channels.
-    pub(crate) fn new(channels: &[String]) -> Subscribe {
-        Subscribe {
-            channels: channels.to_vec(),
-        }
+    pub(crate) fn new(channels: Vec<String>) -> Subscribe {
+        Subscribe {channels}
     }
 
     /// Parse a `Subscribe` instance from a received frame.
@@ -288,7 +286,7 @@ impl Unsubscribe {
         }
     }
 
-    /// Parse a `Unsubscribe` instance from a received frame.
+    /// Parse an `Unsubscribe` instance from a received frame.
     ///
     /// The `Parse` argument provides a cursor-like API to read fields from the
     /// `Frame`. At this point, the entire frame has already been received from

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -12,7 +12,7 @@ use tokio::sync::broadcast;
 #[derive(Debug)]
 pub(crate) struct Shutdown {
     /// `true` if the shutdown signal has been received
-    shutdown: bool,
+    is_shutdown: bool,
 
     /// The receive half of the channel used to listen for shutdown.
     notify: broadcast::Receiver<()>,
@@ -22,21 +22,21 @@ impl Shutdown {
     /// Create a new `Shutdown` backed by the given `broadcast::Receiver`.
     pub(crate) fn new(notify: broadcast::Receiver<()>) -> Shutdown {
         Shutdown {
-            shutdown: false,
+            is_shutdown: false,
             notify,
         }
     }
 
     /// Returns `true` if the shutdown signal has been received.
     pub(crate) fn is_shutdown(&self) -> bool {
-        self.shutdown
+        self.is_shutdown
     }
 
     /// Receive the shutdown notice, waiting if necessary.
     pub(crate) async fn recv(&mut self) {
         // If the shutdown signal has already been received, then return
         // immediately.
-        if self.shutdown {
+        if self.is_shutdown {
             return;
         }
 
@@ -44,6 +44,6 @@ impl Shutdown {
         let _ = self.notify.recv().await;
 
         // Remember that the signal has been received.
-        self.shutdown = true;
+        self.is_shutdown = true;
     }
 }


### PR DESCRIPTION
The "shutdown" in mini-redis is confusing since there are too many "shutdown" in the project and the word itself can be either a noun or a verb. So I changed the name of the variable.