### PR TITLE
Add doc about Ping cmd to README, change the internal data type of Ping cmd to Bytes, and rm unnecessary reference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "tracing-futures",
  "tracing-opentelemetry",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ clap = { version = "3.1.18", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
 tracing = "0.1.34"
-tracing-futures = { version = "0.2.3" }
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 # Implements the types defined in the OTel spec
 opentelemetry = { version = "0.17.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ https://github.com/aws-observability/aws-otel-collector/blob/main/docs/developer
 
 `mini-redis` currently supports the following commands.
 
+* [PING](https://redis.io/commands/ping)
 * [GET](https://redis.io/commands/get)
 * [SET](https://redis.io/commands/set)
 * [PUBLISH](https://redis.io/commands/publish)

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -28,7 +28,8 @@ struct Cli {
 enum Command {
     Ping {
         /// Message to ping
-        msg: Option<String>,
+        #[clap(parse(from_str = bytes_from_str))]
+        msg: Option<Bytes>,
     },
     /// Get the value of key.
     Get {

--- a/src/client.rs
+++ b/src/client.rs
@@ -110,7 +110,7 @@ impl Client {
     /// }
     /// ```
     #[instrument(skip(self))]
-    pub async fn ping(&mut self, msg: Option<String>) -> crate::Result<Bytes> {
+    pub async fn ping(&mut self, msg: Option<Bytes>) -> crate::Result<Bytes> {
         let frame = Ping::new(msg).into_frame();
         debug!(request = ?frame);
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -459,7 +459,7 @@ impl Subscriber {
     /// Unsubscribe to a list of new channels
     #[instrument(skip(self))]
     pub async fn unsubscribe(&mut self, channels: &[String]) -> crate::Result<()> {
-        let frame = Unsubscribe::new(&channels).into_frame();
+        let frame = Unsubscribe::new(channels).into_frame();
 
         debug!(request = ?frame);
 

--- a/src/cmd/ping.rs
+++ b/src/cmd/ping.rs
@@ -10,12 +10,12 @@ use tracing::instrument;
 #[derive(Debug, Default)]
 pub struct Ping {
     /// optional message to be returned
-    msg: Option<String>,
+    msg: Option<Bytes>,
 }
 
 impl Ping {
     /// Create a new `Ping` command with optional `msg`.
-    pub fn new(msg: Option<String>) -> Ping {
+    pub fn new(msg: Option<Bytes>) -> Ping {
         Ping { msg }
     }
 
@@ -40,7 +40,7 @@ impl Ping {
     /// PING [message]
     /// ```
     pub(crate) fn parse_frames(parse: &mut Parse) -> crate::Result<Ping> {
-        match parse.next_string() {
+        match parse.next_bytes() {
             Ok(msg) => Ok(Ping::new(Some(msg))),
             Err(ParseError::EndOfStream) => Ok(Ping::default()),
             Err(e) => Err(e.into()),
@@ -55,7 +55,7 @@ impl Ping {
     pub(crate) async fn apply(self, dst: &mut Connection) -> crate::Result<()> {
         let response = match self.msg {
             None => Frame::Simple("PONG".to_string()),
-            Some(msg) => Frame::Bulk(Bytes::from(msg)),
+            Some(msg) => Frame::Bulk(msg),
         };
 
         // Write the response back to the client
@@ -72,7 +72,7 @@ impl Ping {
         let mut frame = Frame::array();
         frame.push_bulk(Bytes::from("ping".as_bytes()));
         if let Some(msg) = self.msg {
-            frame.push_bulk(Bytes::from(msg));
+            frame.push_bulk(msg);
         }
         frame
     }

--- a/src/cmd/ping.rs
+++ b/src/cmd/ping.rs
@@ -1,6 +1,6 @@
 use crate::{Connection, Frame, Parse, ParseError};
 use bytes::Bytes;
-use tracing::instrument;
+use tracing::{debug, instrument};
 
 /// Returns PONG if no argument is provided, otherwise
 /// return a copy of the argument as a bulk.
@@ -57,6 +57,8 @@ impl Ping {
             None => Frame::Simple("PONG".to_string()),
             Some(msg) => Frame::Bulk(msg),
         };
+
+        debug!(?response);
 
         // Write the response back to the client
         dst.write_frame(&response).await?;

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -21,7 +21,7 @@ async fn ping_pong_with_message() {
     let (addr, _) = start_server().await;
     let mut client = client::connect(addr).await.unwrap();
 
-    let pong = client.ping(Some("你好世界".to_string())).await.unwrap();
+    let pong = client.ping(Some("你好世界".into())).await.unwrap();
     assert_eq!("你好世界".as_bytes(), &pong[..]);
 }
 


### PR DESCRIPTION
As said in the commit messages, I made five changes:

- `doc: add command Ping to README`: currently it's missing.

- `change the internal data type of Ping cmd to Bytes`: according to the [Redis protocol](https://redis.io/commands/ping/), the optional data of Ping command could be `Bulk` type. Currently, it's only `Simple` type.

- `rm unnecessary reference`: complained by Cargo clippy.

- `add tracing to Ping cmd`: to keep consistent with other commands. Another alternative is to remove the instrument annotation on `Ping::apply(self, dst: &mut Connection)`.

- `rm unused dependency tracing-futures`


All the tests have been passed.