### PR TITLE
fix: update aws-xray example link for x-amzn-trace-id

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -62,7 +62,7 @@ fn set_up_logging() -> Result<(), TryInitError> {
     // Note: If you need to pass the x-amzn-trace-id across services in the same trace,
     // you will need this line. However, this requires additional code not pictured here.
     // For a full example using hyper, see:
-    // https://github.com/open-telemetry/opentelemetry-rust/blob/main/examples/aws-xray/src/server.rs#L14-L26
+    // https://github.com/open-telemetry/opentelemetry-rust/blob/v0.19.0/examples/aws-xray/src/server.rs#L14-L26
     global::set_text_map_propagator(XrayPropagator::default());
 
     let tracer = opentelemetry_otlp::new_pipeline()


### PR DESCRIPTION
In latest `opentelemetry-rust` repository, there is no example code for `aws-xray` under the `examples` folder, which still can be found in older commits.