### PR TITLE
Remove unnecessary custom clap value parser

### DIFF
--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -2,7 +2,6 @@ use mini_redis::{clients::Client, DEFAULT_PORT};
 
 use bytes::Bytes;
 use clap::{Parser, Subcommand};
-use std::convert::Infallible;
 use std::num::ParseIntError;
 use std::str;
 use std::time::Duration;
@@ -29,7 +28,6 @@ struct Cli {
 enum Command {
     Ping {
         /// Message to ping
-        #[arg(value_parser = bytes_from_str)]
         msg: Option<Bytes>,
     },
     /// Get the value of key.
@@ -43,7 +41,6 @@ enum Command {
         key: String,
 
         /// Value to set.
-        #[arg(value_parser = bytes_from_str)]
         value: Bytes,
 
         /// Expire the value after specified amount of time
@@ -55,7 +52,6 @@ enum Command {
         /// Name of channel
         channel: String,
 
-        #[arg(value_parser = bytes_from_str)]
         /// Message to publish
         message: Bytes,
     },
@@ -152,8 +148,4 @@ async fn main() -> mini_redis::Result<()> {
 fn duration_from_ms_str(src: &str) -> Result<Duration, ParseIntError> {
     let ms = src.parse::<u64>()?;
     Ok(Duration::from_millis(ms))
-}
-
-fn bytes_from_str(src: &str) -> Result<Bytes, Infallible> {
-    Ok(Bytes::from(src.to_string()))
 }


### PR DESCRIPTION
`clap` can use the appropriate `From` trait of the value type.

https://docs.rs/clap/4.5.13/clap/macro.value_parser.html