### PR TITLE
cmd: preserve publish in subscribe error messages

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -112,7 +112,7 @@ impl Command {
     pub(crate) fn get_name(&self) -> &str {
         match self {
             Command::Get(_) => "get",
-            Command::Publish(_) => "pub",
+            Command::Publish(_) => "publish",
             Command::Set(_) => "set",
             Command::Subscribe(_) => "subscribe",
             Command::Unsubscribe(_) => "unsubscribe",

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -397,6 +397,45 @@ async fn send_error_get_set_after_subscribe() {
     assert_eq!(b"-ERR unknown command \'get\'\r\n", &response);
 }
 
+// In this case we test that server responds with an Error message mentioning
+// PUBLISH if a client sends PUBLISH after SUBSCRIBE.
+#[tokio::test]
+async fn send_error_publish_after_subscribe() {
+    let addr = start_server().await;
+
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+
+    stream
+        .write_all(b"*2\r\n$9\r\nsubscribe\r\n$5\r\nhello\r\n")
+        .await
+        .unwrap();
+
+    let mut response = [0; 34];
+
+    stream.read_exact(&mut response).await.unwrap();
+
+    assert_eq!(
+        &b"*3\r\n$9\r\nsubscribe\r\n$5\r\nhello\r\n:1\r\n"[..],
+        &response[..]
+    );
+
+    stream
+        .write_all(b"*3\r\n$7\r\nPUBLISH\r\n$5\r\nhello\r\n$5\r\nworld\r\n")
+        .await
+        .unwrap();
+
+    let mut response = [0; 32];
+    let bytes_read = time::timeout(Duration::from_secs(1), stream.read(&mut response))
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        b"-ERR unknown command \'publish\'\r\n",
+        &response[..bytes_read]
+    );
+}
+
 async fn start_server() -> SocketAddr {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();


### PR DESCRIPTION
  Changes

  - fix Command::get_name() so Publish reports publish instead
    of pub
  - add a focused regression covering the PUBLISH-after-
    SUBSCRIBE error path

  Why

  When PUBLISH is sent after SUBSCRIBE, the returned unknown-
  command error currently leaks the abbreviated name pub. This
  keeps the error message aligned with the actual command the
  user issued.

  Verification

  - cargo test --test server send_error_publish_after_subscribe
    -- --exact

  Scope

  - src/cmd/mod.rs
  - tests/server.rs