### PR TITLE
Validate NULL bulk strings have expected format

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -78,9 +78,18 @@ impl Frame {
                 Ok(())
             }
             b'$' => {
+                // Bulk strings in the RESP protocol.
+                //
+                // Format: $<length>\r\n<data>\r\n
+                //
+                // Special case: $-1\r\n represents a Null value.
+                // Validates that the frame conforms to RESP protocol.
                 if b'-' == peek_u8(src)? {
-                    // Skip '-1\r\n'
-                    skip(src, 4)
+                    let line = get_line(src)?;
+                    if line != b"-1" {
+                        return Err("protocol error; invalid frame format".into());
+                    }
+                    Ok(())
                 } else {
                     // Read the bulk string
                     let len: usize = get_decimal(src)?.try_into()?;

--- a/tests/frame_validation.rs
+++ b/tests/frame_validation.rs
@@ -1,0 +1,20 @@
+use mini_redis::frame::{Error, Frame};
+use std::io::Cursor;
+
+#[test]
+fn check_rejects_invalid_negative_bulk_length() {
+    // Valid null bulk string in RESP.
+    let mut ok = Cursor::new(&b"$-1\r\n"[..]);
+    assert!(Frame::check(&mut ok).is_ok());
+
+    // Invalid negative bulk length.
+    let mut bad = Cursor::new(&b"$-2\r\n"[..]);
+    let err = Frame::check(&mut bad).unwrap_err();
+
+    match err {
+        Error::Other(e) => {
+            assert_eq!(e.to_string(), "protocol error; invalid frame format");
+        }
+        Error::Incomplete => panic!("expected protocol error, got incomplete"),
+    }
+}


### PR DESCRIPTION
## Context
This PR supersedes #155 with two improvements:
1. Includes a regression test case for the validation logic
2. Created from a dedicated fix branch (`fix/add-validation`) instead of `master`, following proper contribution workflow

Apologies for the earlier confusion with the branch source.

## Summary
Added detailed comments to the Frame::check function's bulk string (b'$') case in src/frame.rs to explain the RESP (Redis Serialization Protocol) format and validation logic.
Added validation for special cases, aligning with `Frame::parse`.

## Changes
### Source code
**File**: `src/frame.rs`
Added comments and validation:
```rust
               // Bulk strings in the RESP protocol.
               //
               // Format: $<length>\r\n<data>\r\n
               //
               // Special case: $-1\r\n represents a Null value.
               // Validates that the frame conforms to RESP protocol.
               if b'-' == peek_u8(src)? {
                    let line = get_line(src)?;
                    if line != b"-1" {
                        return Err("protocol error; invalid frame format".into());
                    }
                    Ok(())
                } else {
                    // Read the bulk string
                    let len: usize = get_decimal(src)?.try_into()?;

                    // skip that number of bytes + 2 (\r\n).
                    skip(src, len + 2)
                }
```

### Test case

**File**:`test/frame_validation.rs`
```rust
use mini_redis::frame::{Error, Frame};
use std::io::Cursor;

#[test]
fn check_rejects_invalid_negative_bulk_length() {
    // Valid null bulk string in RESP.
    let mut ok = Cursor::new(&b"$-1\r\n"[..]);
    assert!(Frame::check(&mut ok).is_ok());

    // Invalid negative bulk length.
    let mut bad = Cursor::new(&b"$-2\r\n"[..]);
    let err = Frame::check(&mut bad).unwrap_err();

    match err {
        Error::Other(e) => {
            assert_eq!(e.to_string(), "protocol error; invalid frame format");
        }
        Error::Incomplete => panic!("expected protocol error, got incomplete"),
    }
}
```
All tests pass locally

## Rationale

- The bulk string case previously had minimal documentation
- Clarifies the expected RESP protocol format for new contributors
- Documents the special Null value case (`$-1\r\n`)
- Improves code maintainability by making the protocol validation logic explicit